### PR TITLE
feat: add checkpoint resume functionality, consolidate weights and custom weights path option for inference

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -72,6 +72,15 @@ python tools/infer.py \
     configs/learnablepooling/json_netvlad++_resnetpca512.py
 ```
 
+#### For E2E, provide the model weights path
+
+```bash
+python tools/infer.py \
+    configs/e2espot/e2espot.py --weights /path/to/your/model/weights
+```
+
+_Note:- If you don't provide the path to the model weights, then the weights are assumed to be inside the cfg.work_dir as "best_checkpoint.pt"_
+
 ### Inference example with custom config file
 
 ```bash

--- a/tools/train.py
+++ b/tools/train.py
@@ -33,7 +33,7 @@ def parse_args():
     # not that important
     parser.add_argument("--seed", type=int, default=42, help="random seed")
     # parser.add_argument("--id", type=int, default=0, help="repeat experiment id")
-    # parser.add_argument("--resume", type=str, default=None, help="resume from a checkpoint")
+    parser.add_argument("--resume-from", type=str, default=None, help="resume from a checkpoint")
     # parser.add_argument("--ema", action="store_true", help="whether to use model EMA")
     # parser.add_argument("--wandb", action="store_true", help="whether to use wandb to log everything")
     # parser.add_argument("--not_eval", action="store_true", help="whether not to eval, only do inference")
@@ -147,6 +147,7 @@ def main():
         cfg.training,
         model,
         get_default_args_trainer(cfg, len(train_loader)),
+        resume_from = args.resume_from
     )
 
     # Start training`


### PR DESCRIPTION
- Add ability to resume training from specific checkpoints
- Consolidate optimizer and model weights into single file
- Reduce number of checkpoint files to 2
- Add --weights argument to specify model weights path for inference
- Implement fallback logic to use best checkpoint from work_dir if no path specified
- Improve logging for model loading process
- Add file existence checks for weight paths
- Update help messages and documentation